### PR TITLE
Fix fontbakery install arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 dist: src/*.js package*.json
-	npm i && npm run package
+	npm i --legacy-peer-deps && NODE_OPTIONS=--openssl-legacy-provider npm run package
 
 update:
 	npm update

--- a/dist/index.js
+++ b/dist/index.js
@@ -5517,18 +5517,18 @@ async function run() {
   try {
     if (fbVersion === "latest") {
       // this installs the latest stable release
-      await exec.exec("python -m pip install --upgrade fontbakery[all_extras]");
+      await exec.exec("python -m pip install --upgrade fontbakery[all]");
     } else if (fbVersion === "pre") {
       // pre-releases happen much more often
-      await exec.exec("python -m pip install --pre --upgrade fontbakery[all_extras]");
+      await exec.exec("python -m pip install --pre --upgrade fontbakery[all]");
     } else if (fbVersion === "main") {
       // here one gets the bleeding edge of the git develoment tree
       await exec.exec(
-        "python -m pip install --upgrade fontbakery[all_extras]@git+https://github.com/googlefonts/fontbakery.git"
+        "python -m pip install --upgrade fontbakery[all]@git+https://github.com/googlefonts/fontbakery.git"
       );
     } else {
       await exec.exec(
-        `python -m pip install --upgrade fontbakery[all_extras]==${fbVersion}`
+        `python -m pip install --upgrade fontbakery[all]==${fbVersion}`
       );
     }
     // Show the installed version

--- a/dist/index.js
+++ b/dist/index.js
@@ -2792,16 +2792,18 @@ exports.create = create;
  * Computes the sha256 hash of a glob
  *
  * @param patterns  Patterns separated by newlines
+ * @param currentWorkspace  Workspace used when matching files
  * @param options   Glob options
+ * @param verbose   Enables verbose logging
  */
-function hashFiles(patterns, options, verbose = false) {
+function hashFiles(patterns, currentWorkspace = '', options, verbose = false) {
     return __awaiter(this, void 0, void 0, function* () {
         let followSymbolicLinks = true;
         if (options && typeof options.followSymbolicLinks === 'boolean') {
             followSymbolicLinks = options.followSymbolicLinks;
         }
         const globber = yield create(patterns, { followSymbolicLinks });
-        return internal_hash_files_1.hashFiles(globber, verbose);
+        return internal_hash_files_1.hashFiles(globber, currentWorkspace, verbose);
     });
 }
 exports.hashFiles = hashFiles;
@@ -5515,18 +5517,18 @@ async function run() {
   try {
     if (fbVersion === "latest") {
       // this installs the latest stable release
-      await exec.exec("python -m pip install --upgrade fontbakery");
+      await exec.exec("python -m pip install --upgrade fontbakery[all_extras]");
     } else if (fbVersion === "pre") {
       // pre-releases happen much more often
-      await exec.exec("python -m pip install --pre --upgrade fontbakery");
+      await exec.exec("python -m pip install --pre --upgrade fontbakery[all_extras]");
     } else if (fbVersion === "main") {
       // here one gets the bleeding edge of the git develoment tree
       await exec.exec(
-        "python -m pip install --upgrade git+https://github.com/googlefonts/fontbakery.git"
+        "python -m pip install --upgrade fontbakery[all_extras]@git+https://github.com/googlefonts/fontbakery.git"
       );
     } else {
       await exec.exec(
-        `python -m pip install --upgrade fontbakery==${fbVersion}`
+        `python -m pip install --upgrade fontbakery[all_extras]==${fbVersion}`
       );
     }
     // Show the installed version
@@ -5670,13 +5672,15 @@ const fs = __importStar(__webpack_require__(747));
 const stream = __importStar(__webpack_require__(794));
 const util = __importStar(__webpack_require__(669));
 const path = __importStar(__webpack_require__(622));
-function hashFiles(globber, verbose = false) {
+function hashFiles(globber, currentWorkspace, verbose = false) {
     var e_1, _a;
     var _b;
     return __awaiter(this, void 0, void 0, function* () {
         const writeDelegate = verbose ? core.info : core.debug;
         let hasMatch = false;
-        const githubWorkspace = (_b = process.env['GITHUB_WORKSPACE']) !== null && _b !== void 0 ? _b : process.cwd();
+        const githubWorkspace = currentWorkspace
+            ? currentWorkspace
+            : (_b = process.env['GITHUB_WORKSPACE']) !== null && _b !== void 0 ? _b : process.cwd();
         const result = crypto.createHash('sha256');
         let count = 0;
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9196,8 +9196,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -9770,8 +9769,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.3.0.tgz",
       "integrity": "sha512-7glNLfvdsMzZm3FpRY1CHuI2lbYDR+71YmrhmTZjYFD5pfT0ACgnGRdrrC9Mk2uICnzkcdelCx5at787UDGOvg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deep-equal": {
       "version": "2.2.0",
@@ -10149,8 +10147,7 @@
       "version": "0.0.19",
       "resolved": "https://registry.npmjs.org/eslint-config-wesbos/-/eslint-config-wesbos-0.0.19.tgz",
       "integrity": "sha512-2NTh0BzSMd1VEE5jEgC40T3QQTrdCEe19mm15m/CV1/314lYtPp5GmM2t26AojxrjfKhBkJR9Thiv6w1U8i/zg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -10364,8 +10361,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.33.1",
@@ -10422,8 +10418,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
       "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "3.7.1",
@@ -11904,8 +11899,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.4.3",

--- a/src/index.js
+++ b/src/index.js
@@ -24,18 +24,18 @@ async function run() {
   try {
     if (fbVersion === "latest") {
       // this installs the latest stable release
-      await exec.exec("python -m pip install --upgrade fontbakery[all_extras]");
+      await exec.exec("python -m pip install --upgrade fontbakery[all]");
     } else if (fbVersion === "pre") {
       // pre-releases happen much more often
-      await exec.exec("python -m pip install --pre --upgrade fontbakery[all_extras]");
+      await exec.exec("python -m pip install --pre --upgrade fontbakery[all]");
     } else if (fbVersion === "main") {
       // here one gets the bleeding edge of the git develoment tree
       await exec.exec(
-        "python -m pip install --upgrade fontbakery[all_extras]@git+https://github.com/googlefonts/fontbakery.git"
+        "python -m pip install --upgrade fontbakery[all]@git+https://github.com/googlefonts/fontbakery.git"
       );
     } else {
       await exec.exec(
-        `python -m pip install --upgrade fontbakery[all_extras]==${fbVersion}`
+        `python -m pip install --upgrade fontbakery[all]==${fbVersion}`
       );
     }
     // Show the installed version

--- a/src/index.js
+++ b/src/index.js
@@ -24,18 +24,18 @@ async function run() {
   try {
     if (fbVersion === "latest") {
       // this installs the latest stable release
-      await exec.exec("python -m pip install --upgrade fontbakery");
+      await exec.exec("python -m pip install --upgrade fontbakery[all_extras]");
     } else if (fbVersion === "pre") {
       // pre-releases happen much more often
-      await exec.exec("python -m pip install --pre --upgrade fontbakery");
+      await exec.exec("python -m pip install --pre --upgrade fontbakery[all_extras]");
     } else if (fbVersion === "main") {
       // here one gets the bleeding edge of the git develoment tree
       await exec.exec(
-        "python -m pip install --upgrade git+https://github.com/googlefonts/fontbakery.git"
+        "python -m pip install --upgrade fontbakery[all_extras]@git+https://github.com/googlefonts/fontbakery.git"
       );
     } else {
       await exec.exec(
-        `python -m pip install --upgrade fontbakery==${fbVersion}`
+        `python -m pip install --upgrade fontbakery[all_extras]==${fbVersion}`
       );
     }
     // Show the installed version


### PR DESCRIPTION
Version 0.9 splits off dependencies, so install all of them to be useful across as many projects as possible.

The `all` feature was introduced in 0.9 and is likely less useful if the user sets the version lower, but eh.

Also provide some npm/node tomfoolery to make the thing run.