### PR TITLE
README minor typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Action CI](https://github.com/f-actions/font-bakery/workflows/Action%20CI/badge.svg)](https://github.com/f-actions/font-bakery/actions?query=workflow%3A%22Action+CI%22)
 [![Lint](https://github.com/f-actions/font-bakery/workflows/Lint/badge.svg)](https://github.com/f-actions/font-bakery/actions?query=workflow%3ALint)
 
-This GitHub Action installs the [googlefonts/fontbakery](https://github.com/fonttools/fontbakery) typeface project quality assurance tool and executes the tool on a user-specified filepath as part of a remote continuous integration testing pipeline.  The Action requires a Python v3.8+ runner environment.
+This GitHub Action installs the [fonttools/fontbakery](https://github.com/fonttools/fontbakery) typeface project quality assurance tool and executes the tool on a user-specified filepath as part of a remote continuous integration testing pipeline.  The Action requires a Python v3.8+ runner environment.
 
 ## Quick Start
 


### PR DESCRIPTION
Fixes the fontbakery GH org change in the README text.  I missed this when I changed the URL link in #211 
